### PR TITLE
Adding development definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-assets
-webpack
+.assets-cache
+pgdata*

--- a/README.md
+++ b/README.md
@@ -2,13 +2,58 @@
 
 Docker compose of Foreman in a LB (using haproxy) setup, including basic client (fact uploads), postgres and memcache.
 
-## Installation
+## Requirements
 
-Install `docker-compose` from [docker compose](https://docs.docker.com/compose/install/) (or via native packaging)
+  * Docker Compose **1.6.0+** ([Install from Docker.com](https://docs.docker.com/compose/install/) or via native packaging)
+  * Docker Engine **1.10.0+** ([Install from Docker.com](https://docs.docker.com/engine/installation/linux/rhel/) or via native packaging)
 
-cd into this directory and run `docker-compose build`. This will build postgres image and Foreman (develop branch) image.
+## Usage
 
-Once the environment is up, you may simply login to `http://localhost`. SSL is disabled for this deployment.
+Clone this Repository to you local environment:
+
+```shell
+$ git clone https://github.com/shlomizadok/foreman-docker-compose.git
+$ cd foreman-docker-compose
+```
+In the **bin** directory you will find the **foreman-container** script which includes a few commands to build and run containers.
+
+To build the containers you can on of three commands:
+
+```shell
+$ bin/foreman-container build              # Builds both production and development definitions
+$ bin/foreman-container build-production   # Builds the production definition only
+$ bin/foreman-container build-development  # Builds the development definition only
+```
+
+After the containers are built they can be used. In order to start the **development** and **test** container, it is required to mount your local foreman repository as a volume for the container. You can do so by commenting out and adjusting the following in `docker-compose.development.yml`:
+```yaml
+...
+  # volumes:
+  #   - $HOME/foreman:/usr/src/foreman-development
+...
+```
+
+To start the containers you can us the **up** commands:
+
+```shell
+$ bin/foreman-container up                       # Starts the production definition only
+$ bin/foreman-container up-development           # Starts the development definition only
+```
+
+Executing commands inside a container, like `rake` tasks, can be done using the **run** commands following yours:
+```shell
+$ bin/foreman-container run [...]                # Run commands in a foreman production container
+$ bin/foreman-container run-development [...]    # Run commands in a foreman development container
+```
+
+Tests can be run in the test container with the **test** command:
+```shell
+$ bin/foreman-container test                     # Run tests in a foreman
+```
+
+Once the environment is built and up (either via `make up` or `make up-development`), you may simply login to `http://localhost` (or `http://localhost:3000` for development). SSL is disabled for this deployment.
+
+**Note on the development definition:** It is only suitable if Docker runs natively on your system or running it in a VM syncing your development folder via NFS. It is also required to set the proper path for the volume to be mounted. If not present the container will `exit`.
 
 ## Known issues
 
@@ -22,7 +67,6 @@ require_ssl_smart_proxies=false
 
 
 ### SELinux Denials
-
 
 the way haproxy auto configure itself based on scale, is by quering docker itself, this raises a selinux alert, if you want haproxy to autoconfigure currently you need to setenfore=0.
 

--- a/bin/foreman-container
+++ b/bin/foreman-container
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+build-production () {
+  echo "=> Building docker production images"
+  docker-compose -f docker-compose.yml build
+}
+
+build-development () {
+  echo "=> Building docker development images"
+  docker-compose -f docker-compose.development.yml build
+}
+
+build () {
+  build-production
+  build-development
+  echo "=> Docker images built."
+}
+
+up-development () {
+  docker-compose -f docker-compose.development.yml up
+}
+
+up() {
+  docker-compose -f docker-compose.yml up
+}
+
+run-test () {
+  echo "=> Running tests"
+  docker-compose -f docker-compose.development.yml run foreman-test "${@:-1}"
+}
+
+run-development () {
+  echo "=> Running command in foreman-development"
+  docker-compose -f docker-compose.development.yml run foreman-development "${@:-1}"
+}
+
+run () {
+  echo "=> Running command in foreman"
+  docker-compose -f docker-compose.yml run foreman "${@:-1}"
+}
+
+"$@"

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,51 @@
+version: '2'
+services:
+  foreman-development:
+    build:
+      context: foreman
+      args:
+        foreman_mode: development
+        foreman_version: develop
+    environment:
+      FOREMAN_MODE: development
+      BUNDLE_WITHOUT: "mysql:mysql2:jenkins:openid:libvirt"
+    command: foreman start
+    ports:
+      - 3000:3000
+    # volumes:
+    #   - $HOME/foreman:/usr/src/foreman-development
+    links:
+      - db
+      - proxy
+
+  foreman-test:
+    build:
+      context: foreman
+      args:
+        foreman_mode: test
+        foreman_version: develop
+    command: bundle exec rake test
+    # volumes:
+    #   - $HOME/foreman:/usr/src/foreman-development
+    links:
+      - db
+
+  db:
+    image: postgres
+    environment:
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    volumes:
+      - ./pgdata-development:/var/lib/postgresql/data/pgdata:z
+
+  proxy:
+    build: proxy
+    command: /usr/src/app/bin/smart-proxy
+    ports:
+      - 8001:8000
+
+  client:
+    build: client
+    environment:
+      - FOREMAN_URL=http://foreman:3000
+    depends_on:
+      - foreman-development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,35 @@
 version: '2'
 services:
+  foreman:
+    build:
+      context: foreman
+      args:
+        foreman_version: 1.13-stable
+        foreman_mode: production
+    environment:
+      FOREMAN_MODE: production
+      BUNDLE_WITHOUT: "mysql:test:mysql2:development:sqlite:jenkins:openid:libvirt"
+    command: rails server -p 80 -b 0.0.0.0
+    ports:
+      - 80
+    volumes:
+      - ./.assets-cache/production/assets:/usr/src/foreman/public/assets:z
+      - ./.assets-cache/production/webpack:/usr/src/foreman/public/webpack:z
+    links:
+      - db
+      - memcache
+      - proxy
+
   memcache:
     image: memcached
+
   db:
     image: postgres:9.5
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - ./pgdata:/var/lib/postgresql/data/pgdata:z
-  foreman:
-    build: foreman
-    command: rails server -p 80 -b 0.0.0.0
-    ports:
-      - 80
-    volumes:
-      - ./assets:/usr/src/app/public/assets:z
-      - ./webpack:/usr/src/app/public/webpack:z
-    links:
-      - db
-      - memcache
-      - proxy
+
   haproxy:
     image: dockercloud/haproxy
     volumes:
@@ -40,11 +50,3 @@ services:
       - FOREMAN_URL=http://haproxy
     depends_on:
       - haproxy
-  foreman-init:
-    build: foreman
-    command: bundle exec rake db:migrate db:seed assets:clean assets:precompile webpack:compile apipie:cache:index
-    volumes:
-      - ./assets:/usr/src/app/public/assets
-      - ./webpack:/usr/src/app/public/webpack
-    depends_on:
-      - db

--- a/foreman/Dockerfile
+++ b/foreman/Dockerfile
@@ -1,20 +1,34 @@
 FROM fedora:latest
-#RUN dnf -y update
-RUN dnf -y install ruby{,-devel,gems} rubygem-{nokogiri,bundler,unf_ext,rdoc} redhat-rpm-config nodejs npm git postgresql-devel gcc-c++ make hostname
-RUN dnf clean all
-LABEL MAINTAINER="ohadlevy@gmail.com"
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
+MAINTAINER Ohad Levy "ohadlevy@gmail.com"
 
-ENV RAILS_ENV=production
-ENV FOREMAN_APIPIE_LANGS=en
-ENV REPO_URL=https://github.com/theforeman/foreman.git
+ARG foreman_version
+ARG foreman_mode
 
-#TODO: support local path instead of checkout
-RUN git clone ${REPO_URL} /usr/src/app
-RUN [ -e 'package.json' ] && npm install || exit 0
-ADD database.yml config/database.yml
-ADD Gemfile.local.rb bundler.d/Gemfile.local.rb
-ADD settings.yaml config/settings.yaml
-RUN bundle --without mysql:test:mysql2:development:sqlite:jenkins:openid:libvirt
+ENV FOREMAN_MODE $foreman_mode
+ENV FOREMAN_VERSION $foreman_version
+
+ENV RAILS_ENV $FOREMAN_MODE
+
+ENV FOREMAN_APIPIE_LANGS en
+ENV FOREMAN_PATH /usr/src/foreman
+ENV REPO_URL https://github.com/theforeman/foreman.git
+ENV BUNDLE_WITHOUT mysql:test:mysql2:development:sqlite:jenkins:openid:libvirt
+
+RUN mkdir -p $FOREMAN_PATH
+WORKDIR /$FOREMAN_PATH
+
+COPY ./support/start.sh /start.sh
+COPY ./support/bootstrap.sh /bootstrap.sh
+COPY ./support/install-packages.sh /install-packages.sh
+RUN /install-packages.sh
+
+RUN git clone $REPO_URL $FOREMAN_PATH
+
+COPY database.yml $FOREMAN_PATH/config/database.yml
+COPY Gemfile.local.rb $FOREMAN_PATH/bundler.d/
+COPY settings.yaml $FOREMAN_PATH/config/settings.yaml
+
+RUN /start.sh /bootstrap.sh
+
+ENTRYPOINT ["sh", "/start.sh"]

--- a/foreman/Gemfile.local.rb
+++ b/foreman/Gemfile.local.rb
@@ -1,6 +1,7 @@
 gem 'puma-rails', :platform => :ruby
 gem 'foreman'
 gem 'rdoc' # until https://github.com/theforeman/foreman/pull/3632 is merged.
+gem "activerecord-nulldb-adapter"
 
 gem "foreman_memcache",         :github => "theforeman/foreman_memcache"
 #gem "foreman_discovery",        :github => "theforeman/foreman_discovery", :branch => 'develop'

--- a/foreman/database.yml
+++ b/foreman/database.yml
@@ -1,5 +1,5 @@
 production: &default
-  adapter: postgresql
+  adapter: <%= ENV['DB_ADAPTER'] ||= 'postgresql' %>
   encoding: unicode
   database: postgres
   pool: 5
@@ -7,6 +7,10 @@ production: &default
   password:
   host: db
 
+development:
+  <<: *default
+  database: foreman_development
+
 test:
   <<: *default
-  database: myapp_test
+  database: foreman_test

--- a/foreman/support/bootstrap.sh
+++ b/foreman/support/bootstrap.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ "$FOREMAN_MODE" = "production" ]; then
+  echo "=> Switching to Foreman version: $FOREMAN_VERSION"
+  git fetch origin
+  git checkout "$FOREMAN_VERSION" || exit
+fi
+
+echo "=> Bundle without: $BUNDLE_WITHOUT"
+bundle --without "$BUNDLE_WITHOUT"
+
+echo "=> Installing node modules"
+npm install
+npm prune
+
+echo "=> Compiling assets"
+DB_ADAPTER=nulldb bundle exec rake assets:clean assets:precompile webpack:compile
+
+touch "$FOREMAN_PATH/.bootstrap"

--- a/foreman/support/install-packages.sh
+++ b/foreman/support/install-packages.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+COMMON_PACKAGES="ruby-devel rubygems rubygem-nokogiri rubygem-bundler rubygem-unf_ext
+                 rubygem-rdoc redhat-rpm-config nodejs npm git postgresql-devel gcc-c++
+                 make hostname"
+
+if [ "$FOREMAN_MODE" = "production" ]; then
+  FOREMAN_SYSTEM_GEMS="bundler puma"
+else
+  FOREMAN_SYSTEM_GEMS="bundler foreman puma"
+fi
+
+echo "=> Installing packages for $FOREMAN_MODE"
+
+echo "Common packages: $COMMON_PACKAGES"
+dnf -y install $COMMON_PACKAGES
+
+echo "=> Installing RubyGems for $FOREMAN_MODE"
+gem install $FOREMAN_SYSTEM_GEMS
+
+echo "=> Updating npm"
+npm install -g npm
+
+echo "=> Cleaning up after packages"
+dnf clean all

--- a/foreman/support/start.sh
+++ b/foreman/support/start.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+echo "=> Running start.sh"
+echo "=> Foreman mode: $FOREMAN_MODE"
+
+if [ "$FOREMAN_MODE" = "development" ]; then
+  echo "=> Switching to development mode"
+  export FOREMAN_PATH="$FOREMAN_PATH-development"
+  mkdir -p "$FOREMAN_PATH"
+fi
+
+echo "=> Moving into $FOREMAN_PATH"
+cd "$FOREMAN_PATH" || exit
+
+if [ "$FOREMAN_MODE" = "development" ] && [ ! -e "$FOREMAN_PATH/Procfile" ]; then
+  echo "!=> No Procfile: assuming no app"
+  echo "!=> Exiting."
+  exit 0
+fi
+
+if [ "$FOREMAN_MODE" = "production" ] && [ -e "$FOREMAN_PATH/.bootstrap" ]; then
+  echo "=> Bootstrapping database"
+  bundle exec rake db:create db:migrate apipie:cache db:seed
+
+  rm "$FOREMAN_PATH/.bootstrap"
+fi
+
+if [ -n "$@" ]; then
+  exec "$@"
+else
+  exit 0
+fi


### PR DESCRIPTION
This adds a separate compose definition for a development environment to start, which only consists of `foreman`, `proxy`, `db` and `client`. 

It also cleans up the bootstrapping process with switches to install dependencies based on an environment variable set in each definition as build arguments and environment variables to run the containers.

The `foreman_version` argument allow now to pass in a specific git branch to be cloned. Cloning now has set `--depth 1` to not clone history and keep the containers small.

Migrating and and bundling happens now on first start of a container and leaves a mark to skip it on following starts in development this is skipped all together to allow installing and bootstrapping manually.

Asset volume paths are now combined into `.asset-cache` and ignored together with pgdata directories.

To easily build and up the containers there is now a `Makefile` with tasks, which are listed in the `README.md`.

It still needs a bit of tweaking there are some quirks with bootstrapping the database.
