### PR TITLE
add zlib-devel to fix foreman build

### DIFF
--- a/foreman/Dockerfile
+++ b/foreman/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 #RUN dnf -y update
-RUN dnf -y install ruby{,-devel,gems} rubygem-{nokogiri,bundler,unf_ext,rdoc} redhat-rpm-config nodejs npm git postgresql-devel gcc-c++ make hostname
+RUN dnf -y install ruby{,-devel,gems} rubygem-{nokogiri,bundler,unf_ext,rdoc} redhat-rpm-config nodejs npm git postgresql-devel gcc-c++ make hostname zlib-devel
 RUN dnf clean all
 LABEL MAINTAINER="ohadlevy@gmail.com"
 


### PR DESCRIPTION
I've added zlib-devel to the packages that need to be installed in the Foreman docker build, otherwise it fails while installing the nokogiri gem, and gives following error:

```bash
Installing nokogiri 1.7.2 with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/share/gems/gems/nokogiri-1.7.2/ext/nokogiri
/usr/bin/ruby -r ./siteconf20170519-1-td173z.rb extconf.rb
checking if the C compiler accepts ... yes
Building nokogiri using packaged libraries.
Using mini_portile version 2.1.0
checking for gzdopen() in -lz... no
zlib is missing; necessary for building libxml2
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
```

