### PR TITLE
Make `docker-compose up` work again

### DIFF
--- a/foreman/Dockerfile
+++ b/foreman/Dockerfile
@@ -1,8 +1,23 @@
 FROM fedora:latest
-#RUN dnf -y update
-RUN dnf -y install ruby{,-devel,gems} rubygem-{nokogiri,bundler,unf_ext,rdoc} redhat-rpm-config nodejs npm git postgresql-devel gcc-c++ make hostname
-RUN dnf clean all
+
 LABEL MAINTAINER="ohadlevy@gmail.com"
+
+#RUN dnf -y update
+RUN dnf -y install \
+    ruby{,-devel,gems} \
+    rubygem-{nokogiri,bundler,unf_ext,rdoc} \
+    redhat-rpm-config \
+    nodejs \
+    npm \
+    git \
+    libcurl-devel \
+    libxml2-devel \
+    postgresql-devel \
+    systemd-devel \
+    gcc-c++ \
+    make \
+    hostname \
+ && dnf clean all
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/foreman/Gemfile.local.rb
+++ b/foreman/Gemfile.local.rb
@@ -2,15 +2,15 @@ gem 'puma-rails', :platform => :ruby
 gem 'foreman'
 gem 'rdoc' # until https://github.com/theforeman/foreman/pull/3632 is merged.
 
-gem "foreman_memcache",         :github => "theforeman/foreman_memcache"
-#gem "foreman_discovery",        :github => "theforeman/foreman_discovery", :branch => 'develop'
-#gem "foreman_dhcp_browser",     :github => "theforeman/foreman_dhcp_browser"
-#gem 'foreman_bootdisk',         :github => 'theforeman/foreman_bootdisk'
-#gem 'foreman_graphite',         :github => 'theforeman/foreman_graphite'
-#gem 'foreman_templates',        :github => 'theforeman/foreman_templates'
-#gem 'foreman_remote_execution', :github => 'theforeman/foreman_remote_execution'
-#gem 'foreman_expire_hosts',     :github => 'theforeman/foreman_expire_hosts'
-#gem 'foreman_cockpit',          :github => 'theforeman/foreman_cockpit'
-#gem 'foreman_openscap',         :github => 'theforeman/foreman_openscap'
-#gem 'foreman_ansible',         :github => 'theforeman/foreman_ansible'
-#gem 'foreman_docker',           :github => 'theforeman/foreman-docker'
+gem "foreman_memcache",         :git => 'https://github.com/theforeman/foreman_memcache'
+#gem "foreman_discovery",        :git => 'https://github.com/theforeman/foreman_discovery', :branch => 'develop'
+#gem "foreman_dhcp_browser",     :git => 'https://github.com/theforeman/foreman_dhcp_browser"
+#gem 'foreman_bootdisk',         :git => 'https://github.com/theforeman/foreman_bootdisk'
+#gem 'foreman_graphite',         :git => 'https://github.com/theforeman/foreman_graphite'
+#gem 'foreman_templates',        :git => 'https://github.com/theforeman/foreman_templates'
+#gem 'foreman_remote_execution', :git => 'https://github.com/theforeman/foreman_remote_execution'
+#gem 'foreman_expire_hosts',     :git => 'https://github.com/theforeman/foreman_expire_hosts'
+#gem 'foreman_cockpit',          :git => 'https://github.com/theforeman/foreman_cockpit'
+#gem 'foreman_openscap',         :git => 'https://github.com/theforeman/foreman_openscap'
+#gem 'foreman_ansible',          :git => 'https://github.com/theforeman/foreman_ansible'
+#gem 'foreman_docker',           :git => 'https://github.com/theforeman/foreman-docker'


### PR DESCRIPTION
The changes in this PR makes `docker-compose build` (and  `docker-compose up`) build the project successfully again.

- Adds development packages now required
- Address warnings on pulling Gemfile resources insecurely
