### PR TITLE
foreman docker needs bzip2

### DIFF
--- a/foreman/Dockerfile
+++ b/foreman/Dockerfile
@@ -17,6 +17,7 @@ RUN dnf -y install \
     gcc-c++ \
     make \
     hostname \
+    bzip2 \
  && dnf clean all
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
foreman docker needs bzip2 otherwise it can't extract phantomjs.

This PR fixes this:

```
Error extracting archive
Phantom installation failed { Error: Command failed: tar jxf /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
tar (child): bzip2: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now

    at ChildProcess.exithandler (child_process.js:294:12)
    at ChildProcess.emit (events.js:182:13)
    at maybeClose (internal/child_process.js:962:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:251:5)
  killed: false,
  code: 2,
  signal: null,
  cmd:
   'tar jxf /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2' } Error: Command failed: tar jxf /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
tar (child): bzip2: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now

    at ChildProcess.exithandler (child_process.js:294:12)
    at ChildProcess.emit (events.js:182:13)
    at maybeClose (internal/child_process.js:962:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:251:5)
```